### PR TITLE
Add post-promotion smoke workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+
+PY?=python
+run:
+	IRONCLAD_PROFILE=$(PROFILE) $(PY) -m ironclad.runner.run_board --season $(SEASON) --week $(WEEK)
+lint:
+	ruff check src
+	black --check src
+	mypy src
+test:
+	pytest -q
+format:
+	black src tests
+ci: format lint test
+
+
+smoke-prod:
+	. .venv/bin/activate && python scripts/smoke/post_promo_smoke.py PROFILE=$${PROFILE:-prod} DUCK=$${DUCK:-out/ironclad.duckdb}
+
+# convenience: validate → promote → smoke (fails fast)
+promote-and-smoke:
+	. .venv/bin/activate && \
+	RUN_A=$${RUN_A} RUN_B=$${RUN_B} make guardrails-validate && \
+	RUN_A=$${RUN_A} RUN_B=$${RUN_B} make promote && \
+	make smoke-prod PROFILE=$${PROFILE:-prod}

--- a/pages/00_Health.py
+++ b/pages/00_Health.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+
+import duckdb
+import pandas as pd
+import streamlit as st
+
+st.set_page_config(page_title="Ironclad — Health", layout="wide")
+st.title("Ironclad — Health / Smoke")
+
+profile = st.selectbox("Profile", ["prod", "qa", "replay"], index=0)
+season = st.text_input("Season (optional)", value="")
+week = st.text_input("Week (optional)", value="")
+slack = st.text_input("Slack webhook (optional)", type="password")
+
+if st.button("Run smoke now"):
+    env = os.environ.copy()
+    env["PROFILE"] = profile
+    if season:
+        env["SEASON"] = season
+    if week:
+        env["WEEK"] = week
+    if slack:
+        env["SLACK_WEBHOOK"] = slack
+    code = subprocess.call(["python", "scripts/smoke/post_promo_smoke.py"], env=env)
+    st.write(f"Smoke finished with exit code {code} (see out/reports/ for artifacts)")
+
+query = (
+    "SELECT run_id, season, week, profile, started_at FROM runs ORDER BY started_at DESC "
+    "NULLS LAST LIMIT 10"
+)
+df = pd.DataFrame()
+try:
+    with duckdb.connect("out/ironclad.duckdb", read_only=True) as con:
+        df = con.execute(query).df()
+except Exception as exc:  # pragma: no cover - UI helper
+    st.warning(f"Could not load recent runs: {exc}")
+
+st.subheader("Recent runs")
+st.dataframe(df, use_container_width=True, hide_index=True)

--- a/scripts/smoke/post_promo_smoke.py
+++ b/scripts/smoke/post_promo_smoke.py
@@ -1,0 +1,140 @@
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import duckdb
+import requests
+
+DUCK = os.environ.get("DUCK", "out/ironclad.duckdb")
+PROFILE = os.environ.get("PROFILE", "prod")
+SEASON = os.environ.get("SEASON")
+WEEK = os.environ.get("WEEK")
+SEED = os.environ.get("SEED", "123")
+SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK", "")
+
+
+def _run(cmd, extra_env=None, fail_ok=False):
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    print("→", " ".join(cmd))
+    rc = subprocess.call(cmd, env=env)
+    if rc != 0 and not fail_ok:
+        print(f"Command failed: {' '.join(cmd)}")
+        sys.exit(rc)
+    return rc
+
+
+def _latest_run_id(con):
+    q = "SELECT run_id FROM runs ORDER BY started_at DESC NULLS LAST LIMIT 1"
+    row = con.execute(q).fetchone()
+    return row[0] if row else None
+
+
+def _summarize(con, run_id):
+    # basic totals + grade mix + top exposure
+    s = {}
+    picks = con.execute(
+        """
+        SELECT grade, COUNT(*) AS n, SUM(stake_units) AS stake
+        FROM picks WHERE run_id = ?
+        GROUP BY grade
+    """,
+        [run_id],
+    ).df()
+    totals = (
+        con.execute("SELECT SUM(stake_units) FROM picks WHERE run_id = ?", [run_id]).fetchone()[0]
+        or 0.0
+    )
+    s["totals_units"] = float(totals)
+    s["by_grade"] = {
+        str(r["grade"]): {"n": int(r["n"]), "stake": float(r["stake"] or 0.0)}
+        for _, r in picks.iterrows()
+    }
+
+    exposure = con.execute(
+        """
+        SELECT market, side, SUM(stake_units) AS stake
+        FROM picks WHERE run_id = ?
+        GROUP BY market, side
+        ORDER BY stake DESC NULLS LAST
+        LIMIT 10
+    """,
+        [run_id],
+    ).df()
+    s["top_exposure"] = [
+        {"market": market, "side": side, "stake": float(stake)}
+        for market, side, stake in exposure.itertuples(index=False)
+    ]
+    return s
+
+
+def _format_markdown(run_id, summary, profile):
+    lines = []
+    lines.append(f"*Ironclad post-promotion smoke — profile `{profile}`*")
+    lines.append(f"Run: `{run_id}`")
+    lines.append(f"Total stake: *{summary['totals_units']:.2f}u*")
+    if summary.get("by_grade"):
+        parts = []
+        for grade, obj in summary["by_grade"].items():
+            parts.append(f"{grade}: {obj['n']} (∑ {obj['stake']:.2f}u)")
+        lines.append("Grades → " + " | ".join(parts))
+    if summary.get("top_exposure"):
+        lines.append("_Top exposure:_")
+        for row in summary["top_exposure"]:
+            lines.append(f"• {row['market']}:{row['side']} — {row['stake']:.2f}u")
+    return "\n".join(lines)
+
+
+def _maybe_slack(md):
+    if not SLACK_WEBHOOK:
+        print("No SLACK_WEBHOOK set; skipping Slack.")
+        return
+    try:
+        requests.post(SLACK_WEBHOOK, json={"text": md}, timeout=10)
+        print("Posted smoke summary to Slack.")
+    except Exception as exc:  # pragma: no cover - best effort notification
+        print("Slack webhook failed:", exc)
+
+
+def main():
+    # 1) preslate with prod
+    extra = {"PROFILE": PROFILE, "SEED": SEED}
+    if SEASON:
+        extra["SEASON"] = SEASON
+    if WEEK:
+        extra["WEEK"] = WEEK
+    _run(["make", "preslate"], extra_env=extra)
+    _run(["make", "size"], extra_env=extra, fail_ok=True)  # sizing might be a no-op early on
+    _run(["make", "record-run"], extra_env=extra)
+
+    # 2) read latest run and summarize
+    with duckdb.connect(DUCK, read_only=True) as con:
+        run_id = _latest_run_id(con)
+        if not run_id:
+            print("No run found after smoke.")
+            sys.exit(2)
+
+        summary = _summarize(con, run_id)
+    md = _format_markdown(run_id, summary, PROFILE)
+
+    # 3) write report
+    outdir = Path("out/reports")
+    outdir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    (outdir / f"smoke_{PROFILE}_{ts}.md").write_text(md, encoding="utf-8")
+    (outdir / f"smoke_{PROFILE}_{ts}.json").write_text(
+        json.dumps({"run_id": run_id, "summary": summary}, indent=2),
+        encoding="utf-8",
+    )
+    print("\n=== Smoke Summary ===\n" + md)
+
+    # 4) optional Slack
+    _maybe_slack(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ironclad/persist/duckdb_connector.py
+++ b/src/ironclad/persist/duckdb_connector.py
@@ -1,0 +1,87 @@
+import os
+from collections.abc import Iterable
+
+import duckdb
+
+from ..schemas.pick import Pick
+from ..schemas.run_manifest import RunManifest
+
+DDL = {
+    "runs": """
+    CREATE TABLE IF NOT EXISTS runs(
+        run_id TEXT PRIMARY KEY,
+        season INTEGER,
+        week INTEGER,
+        profile TEXT,
+        settings_json JSON,
+        started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );""",
+    "picks": """
+    CREATE TABLE IF NOT EXISTS picks(
+        run_id TEXT,
+        game_id TEXT,
+        season INTEGER,
+        week INTEGER,
+        market TEXT,
+        side TEXT,
+        line DOUBLE,
+        price_american INTEGER,
+        model_prob DOUBLE,
+        fair_price_american INTEGER,
+        ev_percent DOUBLE,
+        z_score DOUBLE,
+        robust_ev_percent DOUBLE,
+        grade TEXT,
+        kelly_fraction DOUBLE,
+        stake_units DOUBLE,
+        book TEXT,
+        ts_created TIMESTAMP
+    );""",
+}
+
+def connect(db_path: str):
+    os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+    con = duckdb.connect(db_path)
+    for ddl in DDL.values():
+        con.execute(ddl)
+    return con
+
+def write_run(con, manifest: RunManifest):
+    con.execute(
+        (
+            "INSERT OR REPLACE INTO runs(run_id, season, week, profile, settings_json) "
+            "VALUES (?, ?, ?, ?, ?);"
+        ),
+        [manifest.run_id, manifest.season, manifest.week, manifest.profile, manifest.settings_json],
+    )
+
+def write_picks(con, picks: Iterable[Pick]):
+    rows = [p.model_dump(mode="json") for p in picks]
+    if not rows:
+        return
+    con.executemany(
+        "INSERT INTO picks VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+        [
+            (
+                r["run_id"],
+                r["game_id"],
+                r["season"],
+                r["week"],
+                r["market"],
+                r["side"],
+                r["line"],
+                r["price_american"],
+                r["model_prob"],
+                r["fair_price_american"],
+                r["ev_percent"],
+                r["z_score"],
+                r["robust_ev_percent"],
+                r["grade"],
+                r["kelly_fraction"],
+                r["stake_units"],
+                r["book"],
+                r["ts_created"],
+            )
+            for r in rows
+        ],
+    )


### PR DESCRIPTION
## Summary
- add a smoke runner script that preslates, sizes, records, and summarizes the latest run with optional Slack delivery
- add Makefile shortcuts for running the smoke flow on prod and chaining validate/promote/smoke, plus a Streamlit health page button
- ensure DuckDB persistence dumps picks as JSON-safe rows and uses executemany so smoke runs and tests succeed

## Testing
- ruff check scripts pages src/ironclad/persist/duckdb_connector.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc8864288083328198baee1834181c