### PR TITLE
Fix lint issues in Streamlit UI and Sheets exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+PY?=python
+run:
+	IRONCLAD_PROFILE=$(PROFILE) $(PY) -m ironclad.runner.run_board --season $(SEASON) --week $(WEEK)
+lint:
+	ruff check src
+	black --check src
+	mypy src
+test:
+	pytest -q
+format:
+	black src tests
+ci: format lint test
+
+ui:
+	. .venv/bin/activate && streamlit run streamlit_app.py
+
+sheets:
+	. .venv/bin/activate && python scripts/export/to_sheets.py --csv_out out/picks/picks_latest.csv
+
+sheets-push:
+	. .venv/bin/activate && python scripts/export/to_sheets.py --sheet "Ironclad Picks" --csv_out out/picks/picks_latest.csv

--- a/README_Schedule.md
+++ b/README_Schedule.md
@@ -1,0 +1,25 @@
+## Streamlit UI
+```bash
+make ui
+# then open the local URL streamlit prints (usually http://localhost:8501)
+```
+
+Google Sheets export
+• Always writes out/picks/picks_latest.csv.
+• To push to a Google Sheet (optional):
+1. Create a Service Account in GCP; download JSON key.
+2. export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+3. Share your target Sheet with the service account email.
+4. make sheets-push (or call the script with --sheet "Your Sheet Name").
+
+---
+
+### quick run (no creds needed)
+
+```bash
+make init
+make schedule
+make preslate
+make ui            # optional UI
+make sheets        # always writes CSV; Sheets push is optional
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+
+[project]
+name = "ironclad"
+version = "2.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2.6",
+  "pydantic-settings>=2.2",
+  "pandas>=2.1",
+  "numpy>=1.26",
+  "duckdb>=1.0.0",
+  "requests>=2.31",
+  "streamlit>=1.37",
+  "structlog>=24.1",
+  "diskcache>=5.6.3",
+  "python-dotenv>=1.0.1",
+  "click>=8.1",
+  "gspread>=6.1",
+  "google-auth>=2.35",
+]
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-cov>=5.0",
+  "responses>=0.25",
+  "ruff>=0.5",
+  "mypy>=1.10",
+  "black>=24.8",
+]
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+[tool.ruff]
+select = ["E","F","I","UP"]
+line-length = 100
+src = ["src"]
+[tool.mypy]
+python_version = "3.11"
+strict = false
+[tool.black]
+line-length = 100
+target-version = ["py311"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+pydantic>=2.6
+pydantic-settings>=2.2
+pandas>=2.1
+numpy>=1.26
+duckdb>=1.0.0
+requests>=2.31
+streamlit>=1.37
+structlog>=24.1
+diskcache>=5.6.3
+python-dotenv>=1.0.1
+click>=8.1
+gspread>=6.1
+google-auth>=2.35

--- a/scripts/export/to_sheets.py
+++ b/scripts/export/to_sheets.py
@@ -1,0 +1,79 @@
+import json
+import os
+import sys
+import time
+
+import click
+import pandas as pd
+
+
+def _load_picks_csv() -> pd.DataFrame:
+    path = "out/picks"
+    if not os.path.isdir(path):
+        return pd.DataFrame()
+
+    files = sorted(f for f in os.listdir(path) if f.endswith("_picks.csv"))
+    if not files:
+        return pd.DataFrame()
+
+    return pd.concat(
+        [pd.read_csv(os.path.join(path, filename)) for filename in files],
+        ignore_index=True,
+    )
+
+
+@click.command()
+@click.option("--sheet", required=False, help="Google Sheet name (tab will be 'Picks').")
+@click.option(
+    "--creds_json",
+    envvar="GOOGLE_APPLICATION_CREDENTIALS",
+    help="Path to service-account JSON.",
+)
+@click.option("--csv_out", default="out/picks/picks_latest.csv", help="Always writes CSV here.")
+def main(sheet: str | None, creds_json: str | None, csv_out: str):
+    started = time.time()
+    df = _load_picks_csv()
+    os.makedirs(os.path.dirname(csv_out), exist_ok=True)
+    df.to_csv(csv_out, index=False)
+    duration = time.time() - started
+    print(f"Wrote CSV: {csv_out} (rows={len(df)}) in {duration:.2f}s")
+
+    if not sheet:
+        print("No --sheet provided → skipping Google Sheets.")
+        return
+    if not creds_json or not os.path.exists(creds_json):
+        print("No Google creds JSON → skipping Google Sheets.")
+        return
+
+    try:
+        import gspread
+        from google.oauth2.service_account import Credentials
+        scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+        creds = Credentials.from_service_account_file(creds_json, scopes=scopes)
+        gc = gspread.authorize(creds)
+        try:
+            sh = gc.open(sheet)
+        except gspread.SpreadsheetNotFound:
+            sh = gc.create(sheet)
+        try:
+            ws = sh.worksheet("Picks")
+            sh.del_worksheet(ws)
+        except Exception:
+            pass
+        ws = sh.add_worksheet(title="Picks", rows=str(max(1000, len(df)+10)), cols="30")
+        if df.empty:
+            ws.update("A1", [["No picks"]])
+            print("Sheet updated (empty).")
+            return
+        ws.update([df.columns.tolist()] + df.astype(str).values.tolist())
+        print(f"Sheet '{sheet}' → tab 'Picks' updated. Rows={len(df)}")
+        print(
+            "Sheet update metadata:",
+            json.dumps({"sheet": sheet, "tab": "Picks", "rows": len(df)}),
+        )
+    except Exception as e:
+        print("Sheets export failed, but CSV is written. Error:", e, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,40 @@
+import duckdb
+import streamlit as st
+
+st.set_page_config(page_title="Ironclad Picks", layout="wide")
+st.title("Ironclad — Picks")
+db = "out/ironclad.duckdb"
+try:
+    con = duckdb.connect(db, read_only=True)
+    df = con.execute("select * from picks order by ts_created desc").df()
+    if df.empty:
+        st.info("No picks yet. Run: `python scripts/ic.py run-preslate`")
+    else:
+        columns = [
+            "run_id",
+            "season",
+            "week",
+            "game_id",
+            "market",
+            "side",
+            "line",
+            "price_american",
+            "model_prob",
+            "ev_percent",
+            "grade",
+            "stake_units",
+            "book",
+            "ts_created",
+        ]
+        for column in columns:
+            if column not in df.columns:
+                df[column] = None
+        st.dataframe(df[columns], use_container_width=True, hide_index=True)
+except Exception as e:
+    st.error(f"Could not read DuckDB at {db}: {e}")
+finally:
+    if "con" in locals():
+        try:
+            con.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- clean up the Streamlit app imports and ensure the DuckDB connection closes cleanly
- reformat the Sheets exporter for Ruff compliance and add a return annotation

## Testing
- ruff check streamlit_app.py scripts/export/to_sheets.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc1a07d0a88332902576304d60b056